### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Stefan Lankes", "Saurav Sachidanand"]
 edition = "2021"
 
 license = "MIT"
-repository = "https://www.github.com/RWTH-OS/xhypervisor"
+repository = "https://github.com/RWTH-OS/xhypervisor"
 documentation = "https://docs.rs/xhypervisor/"
 readme = "README.md"
 description = " Hardware-accelerated virtualization on OS X"


### PR DESCRIPTION
Github redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96

You can find out info about all of your crates here: https://rust-digger.code-maven.com/users/stlankes